### PR TITLE
pkg/markdown: Ignore forbidden elements

### DIFF
--- a/pkg/markdown/markdown_test.go
+++ b/pkg/markdown/markdown_test.go
@@ -41,6 +41,12 @@ var _ = Describe("rendering markdown", func() {
 			`https://calendar.testing`,
 			`<p><a href="https://calendar.testing" target="_blank" rel="noopener">https://calendar.testing</a></p>`,
 		),
+
+		// Any elements not specifically allowed are forbidden.
+		Entry("forbidden element is ignored",
+			"```Text```",
+			`<p></p>`,
+		),
 	)
 
 	DescribeTable("XSS mitigation",
@@ -75,19 +81,6 @@ href="javascript:alert('xss')">you</a>`,
 			`[Link](" onclick="alert('xss')")`,
 			`<p>[Link](&quot; onclick=&quot;alert('xss')&quot;)</p>`,
 		),
-	)
-
-	DescribeTable("forbidden markdown elements",
-		func(source string) {
-			_, err := markdown.Convert(source)
-			Expect(err).To(HaveOccurred())
-		},
-
-		Entry("code block",
-			"```Text```",
-		),
-
-		// Any elements not specifically allowed are forbidden.
 	)
 
 	DescribeTable("linebreaks",


### PR DESCRIPTION
Instead of erroring out, forbidden elements are just ignored. As a side-effect, the markdown renderer can be implemented as a single global instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced Markdown rendering now silently omits unsupported elements, resulting in cleaner, uninterrupted output.
  - Optimized processing reuses configuration across conversions, providing a more consistent and efficient user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->