### PR TITLE
Fix preparing SQLite FTS search string

### DIFF
--- a/model/event_test.go
+++ b/model/event_test.go
@@ -395,6 +395,8 @@ var _ = Describe("full text search", func() {
 		},
 		Entry("multiple exact match at least one", `"Desc 2" "unknown@email.testing"`), // Defaults to AND operator.
 		Entry("only AND operator", "AND"),
+		Entry("multiple operators prefix", "AND AND Desc"),
+		Entry("multiple operators suffix", "Desc AND AND"),
 		Entry("unused AND operator", "AND something"),
 		Entry("backslash", `aou\`),
 		Entry("spaces", "Desc \t \u00a0  3"),

--- a/pkg/textfilter/textfilter.go
+++ b/pkg/textfilter/textfilter.go
@@ -13,9 +13,30 @@ func EnsureQuoted(s string) string {
 }
 
 // PrepareFTSSearchStrings prepares an SQLITE FTS search string of quoted words.
-func PrepareFTSSearchStrings(s string) []string {
+func PrepareFTSSearchStrings(s string) (quoted []string) {
 	fields := splitString(s)
-	quoted := make([]string, 0, len(fields))
+
+first:
+	for len(fields) > 0 {
+		switch first := fields[0]; first {
+		case "AND", "OR", "NOT":
+			fields = fields[1:]
+
+		default:
+			break first
+		}
+	}
+
+last:
+	for len(fields) > 0 {
+		switch last := fields[len(fields)-1]; last {
+		case "AND", "OR", "NOT":
+			fields = fields[:len(fields)-1]
+
+		default:
+			break last
+		}
+	}
 
 	for _, field := range fields {
 		switch field {
@@ -25,26 +46,6 @@ func PrepareFTSSearchStrings(s string) []string {
 		default:
 			quoted = append(quoted, EnsureQuoted(field))
 		}
-	}
-
-	// Remove unused FTS5 operators.
-
-	if len(quoted) == 0 {
-		return nil
-	}
-
-	switch first := quoted[0]; first {
-	case "AND", "OR", "NOT":
-		quoted = quoted[1:]
-	}
-
-	if len(quoted) == 0 {
-		return nil
-	}
-
-	switch last := quoted[len(quoted)-1]; last {
-	case "AND", "OR", "NOT":
-		quoted = quoted[:len(quoted)-1]
 	}
 
 	return quoted

--- a/pkg/textfilter/textfilter_test.go
+++ b/pkg/textfilter/textfilter_test.go
@@ -30,6 +30,18 @@ func TestPrepareFTSSearchStrings(t *testing.T) {
 			source:   `"one one" "two two"`,
 			expected: []string{`"one one"`, `"two two"`},
 		},
+		{
+			source:   `a AND b`,
+			expected: []string{`"a"`, `AND`, `"b"`},
+		},
+		{
+			source:   `AND AND a`,
+			expected: []string{`"a"`},
+		},
+		{
+			source:   `a AND AND`,
+			expected: []string{`"a"`},
+		},
 	} {
 		t.Run(tc.source, func(t *testing.T) {
 			result := textfilter.PrepareFTSSearchStrings(tc.source)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the processing of search queries with multiple operators, ensuring a more consistent and reliable search experience.
  
- **Tests**
  - Expanded test coverage to validate the handling of input variations with different operator placements, strengthening overall query resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->