### PR TITLE
Handle event timezones

### DIFF
--- a/contract/editevent.go
+++ b/contract/editevent.go
@@ -2,19 +2,21 @@ package contract
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/mgnsk/calendar/pkg/snowflake"
 )
 
 // EditEventForm is an edit event form.
 type EditEventForm struct {
-	EventID     snowflake.ID `param:"event_id"`
-	Title       string       `form:"title"`
-	Description string       `form:"desc"`
-	URL         string       `form:"url"`
-	StartAt     DateTime     `form:"start_at"`
-	Location    string       `form:"location"`
+	EventID      snowflake.ID `param:"event_id"`
+	Title        string       `form:"title"`
+	Description  string       `form:"desc"`
+	URL          string       `form:"url"`
+	StartAt      string       `form:"start_at"`
+	Location     string       `form:"location"`
+	Latitude     float64      `form:"latitude"`
+	Longitude    float64      `form:"longitude"`
+	UserTimezone string       `form:"user_timezone"`
 }
 
 // Validate the form.
@@ -35,7 +37,7 @@ func (r *EditEventForm) Validate() url.Values {
 		}
 	}
 
-	if r.StartAt.value.IsZero() {
+	if r.StartAt == "" {
 		errs.Set("start_at", "Required")
 	}
 
@@ -46,44 +48,5 @@ func (r *EditEventForm) Validate() url.Values {
 	return errs
 }
 
-// NewDateTime creates a form datetime from time.Time.
-func NewDateTime(ts time.Time) DateTime {
-	return DateTime{value: ts}
-}
-
-// DateTime is a time type that parses from HTML datetime-local time format.
-type DateTime struct {
-	value time.Time
-}
-
-func (t *DateTime) String() string {
-	if t.value.IsZero() {
-		return ""
-	}
-	return t.value.Format(formDateTimeLayout)
-}
-
-// Time returns the time.Time value.
-func (t *DateTime) Time() time.Time {
-	return t.value
-}
-
-// UnmarshalText unmarshals the form datetime value.
-// TODO: timezone from user
-func (t *DateTime) UnmarshalText(text []byte) error {
-	val := string(text)
-	if val == "" {
-		return nil
-	}
-
-	ts, err := time.Parse(formDateTimeLayout, val)
-	if err != nil {
-		return err
-	}
-
-	t.value = ts
-
-	return nil
-}
-
-const formDateTimeLayout = "2006-01-02T15:04"
+// FormDateTimeLayout is the HTML datetime-local input time format.
+const FormDateTimeLayout = "2006-01-02T15:04"

--- a/domain/event.go
+++ b/domain/event.go
@@ -17,6 +17,8 @@ type Event struct {
 	Description string
 	URL         string
 	Location    string
+	Latitude    float64
+	Longitude   float64
 	IsDraft     bool
 	UserID      snowflake.ID
 }

--- a/handler/editevent.go
+++ b/handler/editevent.go
@@ -246,6 +246,10 @@ func getLocation(ctx context.Context, req contract.EditEventForm) (string, error
 
 	defer res.Body.Close()
 
+	if res.StatusCode != http.StatusOK {
+		return "", wreck.Internal.New(fmt.Sprintf("Unable to reach geotimezone API: status %d", res.StatusCode))
+	}
+
 	var timezoneResponse struct {
 		IANATimezone string `json:"iana_timezone"`
 	}

--- a/html/editevent.go
+++ b/html/editevent.go
@@ -2,6 +2,7 @@ package html
 
 import (
 	"net/url"
+	"strconv"
 
 	"github.com/mgnsk/calendar/contract"
 	. "maragu.dev/gomponents"
@@ -16,7 +17,7 @@ func EditEventMain(form contract.EditEventForm, errs url.Values, csrf string) No
 				Method("POST"),
 				input("title", "text", "Title", form.Title, errs.Get("title"), true),
 				input("url", "url", "URL", form.URL, errs.Get("url"), false),
-				dateTimeLocalInput("start_at", form.StartAt.String(), errs.Get("start_at"), true),
+				dateTimeLocalInput("start_at", form.StartAt, errs.Get("start_at"), true),
 
 				Div(Class("relative"),
 					input("location", "text", "Location", form.Location, errs.Get("location"), true),
@@ -29,6 +30,10 @@ func EditEventMain(form contract.EditEventForm, errs url.Values, csrf string) No
 
 				Input(Type("hidden"), Name("csrf"), Value(csrf)),
 				Input(Type("hidden"), Name("easymde_cache_key"), Value(form.EventID.String())),
+				Input(Type("hidden"), Name("latitude"), Value(strconv.FormatFloat(form.Latitude, 'f', -1, 64))),
+				Input(Type("hidden"), Name("longitude"), Value(strconv.FormatFloat(form.Longitude, 'f', -1, 64))),
+				Input(Type("hidden"), Name("user_timezone")),
+				Script(Raw(`document.querySelector('[name="user_timezone"]').value = Intl.DateTimeFormat().resolvedOptions().timeZone;`)),
 				// TODO: save draft button
 				submitButton("Publish"),
 			),

--- a/html/editevent.js
+++ b/html/editevent.js
@@ -68,7 +68,7 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   $('[name="location"]').autocomplete({
-    source(request, response) {
+    source: function (request, response) {
       const query = request.term.trim();
       if (!query) {
         response([]);
@@ -94,6 +94,13 @@ document.addEventListener("DOMContentLoaded", () => {
         .finally(function () {
           $("#location-spinner").css("opacity", "0");
         });
+    },
+    select: function (_, ui) {
+      const lat = ui.item.y;
+      const long = ui.item.x;
+
+      $('[name="latitude"]').val(lat);
+      $('[name="longitude"]').val(long);
     },
     delay: 500,
     minLength: 3,

--- a/migrations/1_events.up.sql
+++ b/migrations/1_events.up.sql
@@ -6,6 +6,8 @@ CREATE TABLE `events` (
   `description` text NOT NULL,
   `url` text NOT NULL,
   `location` text NOT NULL,
+  `latitude` text NOT NULL,
+  `longitude` text NOT NULL,
   `is_draft` tinyint NOT NULL,
   `user_id` bigint unsigned NOT NULL
 );

--- a/model/event.go
+++ b/model/event.go
@@ -23,6 +23,8 @@ type Event struct {
 	Description    string       `bun:"description"`
 	URL            string       `bun:"url"`
 	Location       string       `bun:"location"`
+	Latitude       float64      `bun:"latitude"`
+	Longitude      float64      `bun:"longitude"`
 
 	IsDraft bool         `bun:"is_draft"`
 	UserID  snowflake.ID `bun:"user_id"`
@@ -63,6 +65,8 @@ func InsertEvent(ctx context.Context, db *bun.DB, ev *domain.Event) error {
 			Description:    ev.Description,
 			URL:            ev.URL,
 			Location:       ev.Location,
+			Latitude:       ev.Latitude,
+			Longitude:      ev.Longitude,
 			IsDraft:        ev.IsDraft,
 			UserID:         ev.UserID,
 		}).Exec(ctx)); err != nil {
@@ -86,6 +90,8 @@ func UpdateEvent(ctx context.Context, db *bun.DB, ev *domain.Event) error {
 				Description:    ev.Description,
 				URL:            ev.URL,
 				Location:       ev.Location,
+				Latitude:       ev.Latitude,
+				Longitude:      ev.Longitude,
 				IsDraft:        ev.IsDraft,
 			}).
 				Column(
@@ -95,6 +101,8 @@ func UpdateEvent(ctx context.Context, db *bun.DB, ev *domain.Event) error {
 					"description",
 					"url",
 					"location",
+					"latitude",
+					"longitude",
 					"is_draft",
 				).
 				Where("id = ?", ev.ID).
@@ -343,6 +351,8 @@ func eventToDomain(ev *Event) *domain.Event {
 		Description: ev.Description,
 		URL:         ev.URL,
 		Location:    ev.Location,
+		Latitude:    ev.Latitude,
+		Longitude:   ev.Longitude,
 		IsDraft:     ev.IsDraft,
 		UserID:      ev.UserID,
 	}

--- a/model/event_test.go
+++ b/model/event_test.go
@@ -28,6 +28,8 @@ var _ = Describe("inserting events", func() {
 				Description: "Desc 1",
 				URL:         "https://calendar.testing",
 				Location:    "hash",
+				Latitude:    1,
+				Longitude:   1,
 				IsDraft:     false,
 				UserID:      snowflake.Generate(),
 			}
@@ -48,6 +50,8 @@ var _ = Describe("inserting events", func() {
 						"Description": Equal(ev.Description),
 						"URL":         Equal(ev.URL),
 						"Location":    Equal("hash"),
+						"Latitude":    Equal(float64(1)),
+						"Longitude":   Equal(float64(1)),
 						"IsDraft":     BeFalse(),
 						"UserID":      Equal(ev.UserID),
 					})),
@@ -67,6 +71,8 @@ var _ = Describe("inserting events", func() {
 							"Description": Equal(ev.Description),
 							"URL":         Equal(ev.URL),
 							"Location":    Equal("hash"),
+							"Latitude":    Equal(float64(1)),
+							"Longitude":   Equal(float64(1)),
 							"IsDraft":     BeFalse(),
 							"UserID":      Equal(ev.UserID),
 						})),
@@ -90,6 +96,8 @@ var _ = Describe("updating events", func() {
 			Description: "Old description",
 			URL:         "https://old.testing",
 			Location:    "old",
+			Latitude:    1,
+			Longitude:   1,
 			IsDraft:     false,
 			UserID:      snowflake.Generate(),
 		}
@@ -113,6 +121,8 @@ var _ = Describe("updating events", func() {
 		ev.URL = "https://new.testing"
 		ev.StartAt = time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC)
 		ev.Location = "new"
+		ev.Latitude = 2
+		ev.Longitude = 2
 		ev.IsDraft = true
 
 		Expect(model.UpdateEvent(ctx, db, ev)).To(Succeed())
@@ -126,6 +136,8 @@ var _ = Describe("updating events", func() {
 				"URL":         Equal("https://new.testing"),
 				"StartAt":     BeTemporally("~", ev.StartAt),
 				"Location":    Equal("new"),
+				"Latitude":    Equal(float64(2)),
+				"Longitude":   Equal(float64(2)),
 				"IsDraft":     BeTrue(),
 			})))
 		})


### PR DESCRIPTION
Determines event timezone when entering events.

The location search bar uses OpenStreetMap API whose response also includes location coordinates.

When saving an event, the coordinates are used to look up the venue timezone. When a venue is used that doesn't exist or timezone is not found, it falls back to user's local timezone. If that is not found, it falls back to UTC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The event editing form now captures additional geographical information (latitude, longitude) and user timezone.
  - Event start times are now adjusted based on the user's location.
  - Location autocomplete has been enhanced to automatically populate coordinate fields.
  - Event data storage has been updated to support mapping and location-based functionality.

- **Bug Fixes**
  - Improved error handling for timezone retrieval and parsing during event editing.

- **Documentation**
  - Updated test cases to validate new geographical fields in event data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->