### PR TITLE
Improve edit event page buttons

### DIFF
--- a/contract/editevent.go
+++ b/contract/editevent.go
@@ -22,6 +22,11 @@ type EditEventForm struct {
 	UserTimezone   string       `form:"user_timezone"`
 }
 
+// IsDraftOrNew reports whether the current event is draft or a new event.
+func (r *EditEventForm) IsDraftOrNew() bool {
+	return r.IsDraft || r.EventID == 0
+}
+
 // Validate the form.
 func (r *EditEventForm) Validate() url.Values {
 	errs := url.Values{}

--- a/html/editevent.go
+++ b/html/editevent.go
@@ -50,7 +50,7 @@ func EditEventMain(form contract.EditEventForm, errs url.Values, csrf string) No
 				Script(Raw(`document.querySelector('[name="user_timezone"]').value = Intl.DateTimeFormat().resolvedOptions().timeZone`)),
 
 				// Draft or new event.
-				Iff(form.IsDraft || form.EventID == 0, func() Node {
+				Iff(form.IsDraftOrNew(), func() Node {
 					return Group{
 						Button(buttonClasses(),
 							Type("submit"),
@@ -67,7 +67,7 @@ func EditEventMain(form contract.EditEventForm, errs url.Values, csrf string) No
 				}),
 
 				// Already published event.
-				Iff(!form.IsDraft, func() Node {
+				Iff(!form.IsDraftOrNew(), func() Node {
 					return Group{
 						Button(buttonClasses(),
 							Type("submit"),

--- a/html/editevent.go
+++ b/html/editevent.go
@@ -49,17 +49,39 @@ func EditEventMain(form contract.EditEventForm, errs url.Values, csrf string) No
 				Input(Type("hidden"), Name("user_timezone")),
 				Script(Raw(`document.querySelector('[name="user_timezone"]').value = Intl.DateTimeFormat().resolvedOptions().timeZone`)),
 
-				Button(buttonClasses(),
-					Type("submit"),
-					Text("Save Draft"),
-					FormAction(fmt.Sprintf("/edit/%s?draft=1", form.EventID.String())),
-				),
-				Button(buttonClasses(),
-					Type("submit"),
-					Text("Publish"),
-					Attr("onclick", "return confirm('Confirm publishing this event')"),
-					FormAction(fmt.Sprintf("/edit/%s?draft=0", form.EventID.String())),
-				),
+				// Draft or new event.
+				Iff(form.IsDraft || form.EventID == 0, func() Node {
+					return Group{
+						Button(buttonClasses(),
+							Type("submit"),
+							Text("Save Draft"),
+							FormAction(fmt.Sprintf("/edit/%s?draft=1", form.EventID.String())),
+						),
+						Button(buttonClasses(),
+							Type("submit"),
+							Text("Publish"),
+							Attr("onclick", "return confirm('Confirm publishing this event')"),
+							FormAction(fmt.Sprintf("/edit/%s?draft=0", form.EventID.String())),
+						),
+					}
+				}),
+
+				// Already published event.
+				Iff(!form.IsDraft, func() Node {
+					return Group{
+						Button(buttonClasses(),
+							Type("submit"),
+							Text("Save"),
+							FormAction(fmt.Sprintf("/edit/%s?draft=0", form.EventID.String())),
+						),
+						Button(buttonClasses(),
+							Type("submit"),
+							Text("Unpublish"),
+							Attr("onclick", "return confirm('Confirm unpublishing this event')"),
+							FormAction(fmt.Sprintf("/edit/%s?draft=1", form.EventID.String())),
+						),
+					}
+				}),
 			),
 		),
 	)


### PR DESCRIPTION
Closes https://github.com/mgnsk/calendar/issues/136.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event editor shows context-aware action buttons:
    * New or draft events: Save Draft and Publish (with confirmation).
    * Published events: Save and Unpublish (with confirmation).
  * Button sets are mutually exclusive and adapt to the event's draft/published state; action destinations remain unchanged.
* **Style**
  * UI now clearly indicates which button set applies (draft/new vs published).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->