### PR TITLE
Feeds: remove base URL

### DIFF
--- a/cmd/calendar/config.go
+++ b/cmd/calendar/config.go
@@ -4,14 +4,12 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 )
 
 // Config is the calendar configuration.
 type Config struct {
 	ListenAddr  string
-	BaseURL     *url.URL
 	DatabaseDir string
 }
 
@@ -19,20 +17,9 @@ type Config struct {
 func LoadConfig() (*Config, error) {
 	var errs []error
 
-	hostname := os.Getenv("HOSTNAME")
-	if hostname == "" {
-		errs = append(errs, fmt.Errorf("hostname: is required"))
-	}
-
-	u, err := url.Parse(fmt.Sprintf("https://%s", hostname))
-	if err != nil {
-		errs = append(errs, fmt.Errorf("hostname: error parsing base URL for hostname: %w", err))
-	}
-
 	c := &Config{
 		ListenAddr:  cmp.Or(os.Getenv("LISTEN_ADDR"), ":8080"),
 		DatabaseDir: os.Getenv("DATABASE_DIR"),
-		BaseURL:     u,
 	}
 
 	if c.ListenAddr == "" {

--- a/cmd/calendar/main.go
+++ b/cmd/calendar/main.go
@@ -172,7 +172,7 @@ func run() error {
 		// Should support conditional get.
 		g := e.Group("")
 
-		h := handler.NewFeedHandler(db, cfg.BaseURL)
+		h := handler.NewFeedHandler(db)
 		h.Register(g)
 	}
 

--- a/handler/feed_test.go
+++ b/handler/feed_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"time"
 
 	ics "github.com/arran4/golang-ical"
@@ -31,7 +30,7 @@ var _ = Describe("RSS feed output", func() {
 		})
 
 		e := echo.New()
-		h := handler.NewFeedHandler(db, Must(url.Parse("https://calendar.testing")))
+		h := handler.NewFeedHandler(db)
 		h.Register(e.Group(""))
 
 		server = httptest.NewServer(e)
@@ -59,7 +58,6 @@ var _ = Describe("RSS feed output", func() {
 				fields := Fields{
 					"FeedType": Equal(string(feedType)),
 					"Title":    Equal("My Awesome Events"),
-					"Link":     Equal("https://calendar.testing/feed"),
 					"Items":    BeEmpty(),
 				}
 
@@ -104,7 +102,6 @@ var _ = Describe("RSS feed output", func() {
 				fields := Fields{
 					"FeedType": Equal(string(feedType)),
 					"Title":    Equal("My Awesome Events"),
-					"Link":     Equal("https://calendar.testing/feed"),
 					"Items": HaveExactElements(
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Title":           Equal(event1.Title),
@@ -157,7 +154,7 @@ var _ = Describe("iCal feed output", func() {
 		})
 
 		e := echo.New()
-		h := handler.NewFeedHandler(db, Must(url.Parse("https://calendar.testing")))
+		h := handler.NewFeedHandler(db)
 		h.Register(e.Group(""))
 
 		server = httptest.NewServer(e)
@@ -188,10 +185,6 @@ var _ = Describe("iCal feed output", func() {
 				HaveField("BaseProperty", MatchFields(IgnoreExtras, Fields{
 					"IANAToken": Equal("DESCRIPTION"),
 					"Value":     Equal("My Awesome Events"),
-				})),
-				HaveField("BaseProperty", MatchFields(IgnoreExtras, Fields{
-					"IANAToken": Equal("URL"),
-					"Value":     Equal("https://calendar.testing/calendar.ics"),
 				})),
 			))
 
@@ -231,10 +224,6 @@ var _ = Describe("iCal feed output", func() {
 				HaveField("BaseProperty", MatchFields(IgnoreExtras, Fields{
 					"IANAToken": Equal("DESCRIPTION"),
 					"Value":     Equal("My Awesome Events"),
-				})),
-				HaveField("BaseProperty", MatchFields(IgnoreExtras, Fields{
-					"IANAToken": Equal("URL"),
-					"Value":     Equal("https://calendar.testing/calendar.ics"),
 				})),
 			))
 


### PR DESCRIPTION
Simplify configuration, the `HOSTNAME` env var is only needed for the caddy proxy.

While the iCal feed is still valid without the URL, the RSS feed does not validate anymore according to w3 - for sake of simpler implementation, we accept it.