### PR TITLE
Fix timezone not applied when saving event

### DIFF
--- a/contract/editevent.go
+++ b/contract/editevent.go
@@ -20,10 +20,9 @@ type EditEventForm struct {
 	OSMType  string `in:"form=osm_type"`
 	OSMID    uint64 `in:"form=osm_id"`
 
-	Latitude       float64 `in:"form=latitude"`
-	Longitude      float64 `in:"form=longitude"`
-	TimezoneOffset int     `in:"form=timezone_offset"`
-	UserTimezone   string  `in:"form=user_timezone"`
+	Latitude     float64 `in:"form=latitude"`
+	Longitude    float64 `in:"form=longitude"`
+	UserTimezone string  `in:"form=user_timezone"`
 }
 
 // IsDraftOrNew reports whether the current event is draft or a new event.

--- a/handler/editevent.go
+++ b/handler/editevent.go
@@ -71,8 +71,6 @@ func (h *EditEventHandler) Edit(w http.ResponseWriter, r *http.Request) {
 			req.OSMID = ev.OSMID
 			req.Latitude = ev.Latitude
 			req.Longitude = ev.Longitude
-			_, offset := ev.StartAt.Zone()
-			req.TimezoneOffset = offset
 		}
 
 		server.RenderPage(w, r, h.sm,

--- a/html/editevent.go
+++ b/html/editevent.go
@@ -47,8 +47,6 @@ func EditEventMain(form contract.EditEventForm, errs url.Values) Node {
 				Input(Type("hidden"), Name("easymde_cache_key"), Value(form.EventID.String())),
 				Input(Type("hidden"), Name("latitude"), Value(strconv.FormatFloat(form.Latitude, 'f', -1, 64))),
 				Input(Type("hidden"), Name("longitude"), Value(strconv.FormatFloat(form.Longitude, 'f', -1, 64))),
-
-				Input(Type("hidden"), Name("timezone_offset"), Value(strconv.FormatInt(int64(form.TimezoneOffset), 10))),
 				Input(Type("hidden"), Name("user_timezone")),
 				Script(Raw(`document.querySelector('[name="user_timezone"]').value = Intl.DateTimeFormat().resolvedOptions().timeZone`)),
 

--- a/html/editevent.js
+++ b/html/editevent.js
@@ -102,6 +102,8 @@ document.addEventListener("DOMContentLoaded", () => {
     select: function (_, ui) {
       document.querySelector('[name="osm_type"]').value = ui.item.raw.osm_type;
       document.querySelector('[name="osm_id"]').value = ui.item.raw.osm_id;
+      document.querySelector('[name="latitude"]').value = ui.item.y;
+      document.querySelector('[name="longitude"]').value = ui.item.x;
     },
     delay: 1000,
     minLength: 3,


### PR DESCRIPTION
The `latitude` and `longitude` hidden input fields were not populated. Events were saved in user timezone.

Tested that Tokyo 5PM event is earlier than Tallinn 3PM.

Possibly fixes https://github.com/mgnsk/calendar/issues/210, awaiting testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added latitude and longitude input fields to event editing, allowing you to precisely specify the geographic location of your event.
  * Location search autocomplete now automatically populates latitude and longitude coordinates when you select a place from the results.

* **Improvements**
  * Simplified timezone handling by replacing the timezone offset field with direct user timezone selection for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->